### PR TITLE
Add CI pipeline to execute unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,18 @@
+
+# SPDX-FileCopyrightText: 2023 Jason Pena <jasonpena@awkless.com>
+# SPDX-License-Identifier: MIT
+
+name: Execute Unit Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get SDL2
+      run: sudo apt-get install libsdl2-dev
+    - name: Checkout Repo
+      uses: actions/checkout@v3
+    - name: Run Tests
+      run: make test


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 Jason Pena <jasonpena@awkless.com>
SPDX-License-Identifier: MIT
-->

# Description

This pull request will allow the CI pipeline to execute unit tests in the code base to ensure that they pass as a form of quality control before merging new changes to production code.

# Area of Effect

CI/CD GitHub Actions.
